### PR TITLE
Call toString() on each parameter before using in MessageFormat.format()

### DIFF
--- a/src/main/java/com/amalstack/notebooksfx/util/http/NamedEndpoint.java
+++ b/src/main/java/com/amalstack/notebooksfx/util/http/NamedEndpoint.java
@@ -1,6 +1,7 @@
 package com.amalstack.notebooksfx.util.http;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 
 public final class NamedEndpoint extends Endpoint {
     private final RouteName routeName;
@@ -12,7 +13,7 @@ public final class NamedEndpoint extends Endpoint {
     }
 
     public NamedEndpoint pathParameters(Object... pathParameters) {
-        this.pathParameters = pathParameters;
+        this.pathParameters = Arrays.stream(pathParameters).map(Object::toString).toArray();
         return this;
     }
 


### PR DESCRIPTION
The `NamedEndpoint` class uses `java.text.MessageFormat.format()` to substitute URL path parameters. Since path parameters are passed as an `Object[]` array (vararg), `MessageFormat` adds separators to long ids.
*Example:* 
```java
MessageFormat.format("notebooks/{id}", 1027)
``` 
is formatted as:
```
notebooks/1,027
```

To avoid such behavior, `NamedEndpoint.pathParameters()` calls `toString()` on each path parameter before using them in `MessageFormat.format()`.