### PR TITLE
Remove trailing slash from group root maps

### DIFF
--- a/src/main/java/com/amalstack/notebooksfx/HelloApplication.java
+++ b/src/main/java/com/amalstack/notebooksfx/HelloApplication.java
@@ -44,7 +44,6 @@ public class HelloApplication extends Application {
         container.addService(SectionRepository.class, HttpSectionRepository.class, Lifetime.TRANSIENT);
         container.addService(PageRepository.class, HttpPageRepository.class, Lifetime.TRANSIENT);
         container.addService(UserRepository.class, HttpUserRepository.class, Lifetime.TRANSIENT);
-
         container.addService(DataAccessService.class, HttpDataAccessService.class, Lifetime.TRANSIENT);
     }
 
@@ -132,18 +131,18 @@ public class HelloApplication extends Application {
 
         RouteTable routeTable = RouteTable.builder()
                 .mapGroup(NOTEBOOKS, "/notebooks", group -> {
-                    group.map("", "/");
+                    group.map("", "");
                     group.map(ID, "/{0}");
                     group.map(USER, "/user");
                 })
                 .mapGroup(SECTIONS, "/sections", group -> {
-                    group.map("", "/");
+                    group.map("", "");
                     group.map(ID, "/{0}");
                     group.mapGroup(NOTEBOOK, "/notebook", subgroup
                             -> subgroup.map(ID, "/{0}"));
                 })
                 .mapGroup(PAGES, "/pages", group -> {
-                    group.map("", "/");
+                    group.map("", "");
                     group.map(ID, "/{0}");
                     group.mapGroup(SECTION, "/section", subgroup
                             -> subgroup.map(ID, "/{0}"));
@@ -165,5 +164,3 @@ public class HelloApplication extends Application {
                 .configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
     }
 }
-
-


### PR DESCRIPTION
In route mappings using `RouteTable.Builder.mapGroup()` like in the following snippet:
```java
.mapGroup(NOTEBOOKS, "/notebooks", group -> {
                    group.map("", "/");
                    group.map("", "");
                    group.map(ID, "/{0}");
                    group.map(USER, "/user");
                });
```
The group root was registered using the following line:
```java
group.map("", "/");
```
When the route `/notebooks` is requested by name, 
```
RouteTable.get(NOTEBOOKS);
```
it would result in the following route:
```
/notebooks/
```
*Note the trailing slash.*
This slash when part of an API URL, may fail to access the requested resource in some API implementations. For instance, the Spring client used with the app currently does not process the request in presence of a trailing slash.